### PR TITLE
rseq fix & some optimization

### DIFF
--- a/src/basics/compound.lisp
+++ b/src/basics/compound.lisp
@@ -669,7 +669,7 @@ Returns differences for a sequence X."
 (defun rseq (a b num)
 "Args: (a b num)
 Returns a list of NUM equally spaced points starting at A and ending at B."
-  (+ a (* (values-list (iseq 0 (1- num))) (/ (float (- b a)) (1- num)))))
+  (+ a (* (iseq 0 (1- num)) (/ (float (- b a)) (1- num)))))
 
 
 


### PR DESCRIPTION
Timed the new version of iseq vs the old.  It's mostly faster, although on huge lists (length 3 million), it's a little iffy.  Not sure why, but at least on small lists it's significantly faster.

Old rseq didn't work because it was written assuming vectorized arithmetic was available, but it isn't, so first fix I made works in package :ls-user, but not in compound.lisp.  Rewrite appears to work.
